### PR TITLE
Use sbt-locales

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,14 @@
 enablePlugins(ScalaJSPlugin)
 enablePlugins(TzdbPlugin)
+enablePlugins(LocalesPlugin)
+
+import locales._
 
 name in ThisBuild := "gemini-locales"
 
 Global / onChangedBuildSource := IgnoreSourceChanges
+
+Global / resolvers += Resolver.sonatypeRepo("public")
 
 val zonesFilterFn = {(z: String) => z == "America/Santiago" || z == "Pacific/Honolulu"}
 
@@ -11,8 +16,15 @@ zonesFilter := zonesFilterFn
 
 dbVersion := TzdbPlugin.Version("2019c")
 
+cldrVersion := CLDRVersion.Version("36")
+
+localesFilter := LocalesFilter.Selection("en-US")
+
+supportNumberFormats := false
+
 libraryDependencies ++= Seq(
-  "io.github.cquiroz" %%% "scala-java-time" % "2.0.0-RC3"
+  "io.github.cquiroz" %%% "scala-java-time" % "2.0.0-RC5",
+  "org.portable-scala" %% "portable-scala-reflect" % "1.0.0"
 )
 
 inThisBuild(Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,6 +2,8 @@ addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.32")
 
 addSbtPlugin("io.github.cquiroz" % "sbt-tzdb" % "0.4.0")
 
+addSbtPlugin("io.github.cquiroz" % "sbt-locales" % "0.3.0")
+
 addSbtPlugin("edu.gemini"            % "sbt-gsp"                  % "0.1.13")
 
 addSbtPlugin("com.geirsson"          % "sbt-ci-release"           % "1.5.2")


### PR DESCRIPTION
This PR is partially an experiment, it uses the new `sbt-locales` plugin to produce a smaller js file when using `scala-java-time`